### PR TITLE
No more missing chevrons

### DIFF
--- a/_includes/css/portfolio.css
+++ b/_includes/css/portfolio.css
@@ -377,13 +377,13 @@ td {
   */
 
   .github-icon{
-    background-image:url(images/github-icon.png);
+    background-image:url("/images/github-icon.png");
     background-size:30px 30px;
     height:30px;
     width:30px;
   }
   .github-icon.light{
-    background-image:url(images/github-icon-white.png);
+    background-image:url("/images/github-icon-white.png");
   }
 
   .project .progress{
@@ -527,21 +527,21 @@ td {
   }
 
   .next-project{
+    background-image: url("//images/chevron-left-black.png");
     left: 30px;
-    background-image: url(images/chevron-left-black.png);
   }
 
   .prev-project{
-    background-image: url(images/chevron-right-black.png);
+    background-image: url("//images/chevron-right-black.png");
     right: 30px;
   }
 
   .next-project.background--dark{
-    background-image: url(images/chevron-left-white.png);
+    background-image: url("//images/chevron-left-white.png");
   }
 
   .prev-project.background--dark{
-    background-image: url(images/chevron-right-white.png);
+    background-image: url("//images/chevron-right-white.png");
   }
 
   .underlined-link{

--- a/css/portfolio.css
+++ b/css/portfolio.css
@@ -377,13 +377,13 @@ td {
   */
 
   .github-icon{
-    background-image:url(images/github-icon.png);
+    background-image:url("/images/github-icon.png");
     background-size:30px 30px;
     height:30px;
     width:30px;
   }
   .github-icon.light{
-    background-image:url(images/github-icon-white.png);
+    background-image:url("/images/github-icon-white.png");
   }
 
   .project .progress{
@@ -398,7 +398,7 @@ td {
   }
 
   .project .progress .under-construction{
-    background-image:url(images/under-construction.png);
+    background-image:url("/images/under-construction.png");
     width:26px;
     height:26px;
     background-size:26px 26px;
@@ -528,20 +528,20 @@ td {
 
   .next-project{
     left: 30px;
-    background-image: url(images/chevron-left-black.png);
+    background-image: url("/images/chevron-left-black.png");
   }
 
   .prev-project{
-    background-image: url(images/chevron-right-black.png);
+    background-image: url("/images/chevron-right-black.png");
     right: 30px;
   }
 
   .next-project.background--dark{
-    background-image: url(images/chevron-left-white.png);
+    background-image: url("/images/chevron-left-white.png");
   }
 
   .prev-project.background--dark{
-    background-image: url(images/chevron-right-white.png);
+    background-image: url("/images/chevron-right-white.png");
   }
 
   .underlined-link{


### PR DESCRIPTION
### Description 

Needed to use leading `/`s to make the chevron image links work. 

**WARNING** There are two `portfolio.css` files. One of them, in `/css/portfolio.css`, is likely useless and should be removed. Will likely do so in another PR. 
