### PR TITLE
Remove padding off header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,4 +1,4 @@
-<header class="site-header px2 px-responsive">
+<header class="site-header px-responsive">
   <div class="mt2 wrap">
       <nav class="">
         {% include navigation.html %}


### PR DESCRIPTION
This class was adding `padding` on right and left, which was limiting the width of the dropdown menu contained inside it. 

It seems that padding is not needed, so I've removed the class which fixes the issue. 

Addresses #22 