### PR TITLE
Fix: menu item underlines were in the wrong spot

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -19,11 +19,11 @@
         {% endif %}
         {% if page.tags contains "projects" %}
           <li class="beliefs-anc">
-            <h4><a class="nav-underline projects" href="{{page.url}}">{{page.title}}</a></h4></li>
+            <h4><a class="nav-underline open-source" href="{{page.url}}">{{page.title}}</a></h4></li>
         {% endif %}
         {% if page.tags contains "resume" %}
           <li class="beliefs-anc">
-            <h4><a class="nav-underline projects" href="{{page.url}}">{{page.title}}</a></h4></li>
+            <h4><a class="nav-underline resume" href="{{page.url}}">{{page.title}}</a></h4></li>
         {% endif %}
       {% endfor %}
           <li>


### PR DESCRIPTION
Turns out 2 items in the dropdown menu used `projects` as a classname, which is an overloaded css classname. `projects` is used elsewhere and so the CSS appropriate there was screwing with the dropdown. 

Addresses #2 